### PR TITLE
Update tests to work as an app inside collab

### DIFF
--- a/src/idea/tests/addidea.py
+++ b/src/idea/tests/addidea.py
@@ -1,25 +1,22 @@
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from haystack import backend
+from haystack import connections
 from idea import models, views
 from idea.tests.utils import mock_req, random_user
 from mock import patch
 
 class AddIdeaTest(TestCase):
-    fixtures = ['state']
-
-    def setUp(self):
-        self.user = User.objects.create_user('testuser', 'test@agency.gov', 'password')
+    fixtures = ['state', 'core-test-fixtures']
 
     def test_good_idea(self):
         """ Test an normal POST submission to add an idea. """
 
-        self.client.login(username='testuser', password='password')
+        self.client.login(username='test1@example.com', password='1')
         self.assertEquals(models.Idea.objects.all().count(), 0)
         num_voters = User.objects.filter(vote__idea__pk=1, vote__vote=1).count()
         self.assertEqual(num_voters, 0)
-        resp = self.client.post(reverse('add_idea'), {'title':'JSON format for HMDA data', 'text':'HMDA data in JSON format. '})
+        resp = self.client.post(reverse('idea:add_idea'), {'title':'JSON format for HMDA data', 'text':'HMDA data in JSON format. '})
         self.assertEqual(resp.status_code, 302)
         self.assertIn('detail', resp['Location'])
         self.assertEquals(models.Idea.objects.all().count(), 1)
@@ -29,7 +26,7 @@ class AddIdeaTest(TestCase):
 
     def test_must_be_logged_in(self):
         """ A user must be logged in to create an idea. """
-        resp = self.client.post(reverse('add_idea'), {'title':'JSON format for HMDA data', 'text':'HMDA data in JSON format. '})
+        resp = self.client.post(reverse('idea:add_idea'), {'title':'JSON format for HMDA data', 'text':'HMDA data in JSON format. '})
         self.assertEqual(resp.status_code, 302)
         self.assertIn('login', resp['Location'])
         self.assertEqual(models.Idea.objects.all().count(), 0)
@@ -42,7 +39,8 @@ class AddIdeaTest(TestCase):
         class Mock():
             pass
         with patch('idea.views.more_like_text') as mlt:
-            backend.SearchBackend().clear()
+            backend = connections['default'].get_backend()
+            backend.clear()
             user = random_user()
             state = models.State.objects.get(name='Active')
             similar1 = models.Idea(creator=user, title='airplanes', state=state,

--- a/src/idea/tests/voting.py
+++ b/src/idea/tests/voting.py
@@ -5,10 +5,9 @@ from idea import models
 from idea.tests.utils import random_user
 
 class VotingTests(TestCase):
-    fixtures = ['state']
+    fixtures = ['state', 'core-test-fixtures']
 
     def setUp(self):
-        self.user = User.objects.create_user('testuser', 'test@agency.gov', 'password')
         self.state = models.State.objects.get(name='Active') 
 
     def test_good_vote(self):
@@ -17,9 +16,9 @@ class VotingTests(TestCase):
                     text='Aliens need assistance.', state=self.state)
         idea.save()
 
-        self.client.login(username='testuser', password='password')
+        self.client.login(username='test1@example.com', password='1')
 
-        resp = self.client.post(reverse('upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea_detail', args=(idea.id,))})
+        resp = self.client.post(reverse('idea:upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea:idea_detail', args=(idea.id,))})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(len(idea.vote_set.all()), 1)
 
@@ -32,12 +31,12 @@ class VotingTests(TestCase):
                     text='Aliens need assistance.', state=self.state)
         idea.save()
 
-        self.client.login(username='testuser', password='password')
-        resp = self.client.post(reverse('upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea_detail', args=(idea.id,))})
+        self.client.login(username='test1@example.com', password='1')
+        resp = self.client.post(reverse('idea:upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea:idea_detail', args=(idea.id,))})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(len(idea.vote_set.all()), 1)
 
-        resp = self.client.post(reverse('upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea_detail', args=(idea.id,))})
+        resp = self.client.post(reverse('idea:upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea:idea_detail', args=(idea.id,))})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(len(idea.vote_set.all()), 1)
 
@@ -48,6 +47,6 @@ class VotingTests(TestCase):
         idea = models.Idea(creator=random_user(), title='Transit subsidy to Mars', 
                     text='Aliens need assistance.', state=self.state)
         idea.save()
-        resp = self.client.post(reverse('upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea_detail', args=(idea.id,))})
+        resp = self.client.post(reverse('idea:upvote_idea'), {'idea_id':idea.id, 'next':reverse('idea:idea_detail', args=(idea.id,))})
         self.assertIn('up', resp['Location'])
 


### PR DESCRIPTION
Notable adjustments:
- Update haystack interface to work with recent versions of haystack
- Use collab's test fixture user so the pages don't get redirected to a register page
- Update redirect pages to work as an app inside collab
