### PR TITLE
Peg django version, thereby reduce the number of tests we need to skip

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,6 +8,9 @@ recipe = zc.recipe.egg
 interpreter = python
 eggs = ${buildout:eggs}
 
+[versions]
+Django = 1.5.4
+
 [django]
 recipe = djangorecipe
 project = idea

--- a/src/idea/tests/search_tests.py
+++ b/src/idea/tests/search_tests.py
@@ -11,13 +11,10 @@ class SearchTest(TestCase):
     backend = connections['default'].get_backend()
     backend_type = connections['default'].backend.__name__
 
-    @unittest.skipIf(backend_type == 'SimpleSearchBackend', 
-            "Simple backend doesn't allow itself to be cleared")
     def setUp(self):
-        self.backend.clear()
+        if SearchTest.backend_type != 'SimpleSearchBackend':
+            self.backend.clear()
 
-    @unittest.skipIf(backend_type == 'SimpleSearchBackend', 
-            "See https://github.com/toastdriven/django-haystack/issues/908")
     def test_add_idea_title(self):
         """
         Check that adding a new idea allows title to be immediately
@@ -34,8 +31,6 @@ class SearchTest(TestCase):
         results = self.backend.search('example_title')
         self.assertEqual(1, results['hits'])
 
-    @unittest.skipIf(backend_type == 'SimpleSearchBackend', 
-            "See https://github.com/toastdriven/django-haystack/issues/908")
     def test_add_idea_summary(self):
         """
         Check that adding a new idea allows title to be immediately
@@ -52,8 +47,6 @@ class SearchTest(TestCase):
         results = self.backend.search('example_summary')
         self.assertEqual(1, results['hits'])
 
-    @unittest.skipIf(backend_type == 'SimpleSearchBackend', 
-            "See https://github.com/toastdriven/django-haystack/issues/908")
     def test_add_idea_text(self):
         """
         Check that adding a new idea allows title to be immediately
@@ -112,8 +105,6 @@ class SearchTest(TestCase):
         results = self.backend.search('example_tag')
         self.assertEqual(1, results['hits'])
 
-    @unittest.skipIf(backend_type == 'SimpleSearchBackend', 
-            "See https://github.com/toastdriven/django-haystack/issues/908")
     def test_banner_title(self):
         """
         Check that adding a new idea allows title to be immediately
@@ -127,8 +118,6 @@ class SearchTest(TestCase):
         results = self.backend.search('example_title')
         self.assertEqual(1, results['hits'])
 
-    @unittest.skipIf(backend_type == 'SimpleSearchBackend', 
-            "See https://github.com/toastdriven/django-haystack/issues/908")
     def test_banner_text(self):
         """
         Check that adding a new idea allows title to be immediately


### PR DESCRIPTION
Stems from a conversation with @m3brown -- several tests were skipped because of https://github.com/toastdriven/django-haystack/issues/908 (a bug rising from the latest haystack + django 1.6). Instead of skipping the tests, this patch fixes the django version used when testing (to before 1.6).
