### PR TITLE
Style updates

### DIFF
--- a/src/idea/static/idea/css/idea.css
+++ b/src/idea/static/idea/css/idea.css
@@ -290,10 +290,6 @@ ul.section-nav li.active a {
 .sidebar-nav {
     margin-bottom: 2.5em;
 }
-.sidebar h4 {
-    font-size: 120%; /* 24px */
-    line-height: 0.95;
-}
 .sidebar .challenge-banner {
     margin-bottom: 2.5em;
     background-color: #DBEDD4;

--- a/src/idea/templates/idea/banner_detail.html
+++ b/src/idea/templates/idea/banner_detail.html
@@ -102,7 +102,7 @@
                         <a href="{% url 'idea:add_idea' %}" class="btn-huge">Submit an idea</a>
                     </div><!-- /project-add-idea -->
                     <aside class="tags">
-                        <h4>Browse by Tag:</h4>
+                        <h3>Browse by Tag:</h3>
                         <ul>
                             {% for tag in tags %}
                             <li class="tag">

--- a/src/idea/templates/idea/detail.html
+++ b/src/idea/templates/idea/detail.html
@@ -106,7 +106,7 @@
                                 <a href="{% url 'idea:add_idea' %}" class="btn-huge">Submit an idea</a>
                             </aside><!-- /project-add-idea -->
                             <aside class="voters">
-                                <h4>Liked by</h4>
+                                <h3>Liked by</h3>
                                 <ul>
                                 {% for voter in voters %}
                                     {% if voter.profile %}
@@ -118,7 +118,7 @@
                                 </ul>                
                             </aside>    
                             <aside class="tags">
-                                <h4>Idea Tags</h4>
+                                <h3>Idea Tags</h3>
                                 <ul>
                                     {% for tag in tags %}
                                     <li class="tag"><a class="tag_name" href="{{tag.tag_url}}">{{tag}}</a>

--- a/src/idea/templates/idea/list.html
+++ b/src/idea/templates/idea/list.html
@@ -117,7 +117,7 @@
                     </div><!-- /challenge-banner -->
                     {% endif %}
                     <aside class="tags">
-                        <h4>Browse by Tag:</h4>
+                        <h3>Browse by Tag:</h3>
                         <ul>
                             {% for tag in tags %}
                             <li class="tag">


### PR DESCRIPTION
- The "Add tag" form below the tags in the detail page has a help text `Separate tags with comma`
  - Now that the form has an autocomplete drop-down, separating multiple tags with commas is still possible/legal but is not intuitive.  It would be a simpler experience if we do not advertise the functionality.
- Update color of selectize tag buttons
