### PR TITLE
Fix add_idea when multiple States have no previous

### DIFF
--- a/src/idea/utility/state_helper.py
+++ b/src/idea/utility/state_helper.py
@@ -2,4 +2,8 @@ from idea.models import State
 
 def get_first_state():
     """ Get the first state for an idea. """
-    return State.objects.get(previous__isnull=True)
+    #return State.objects.get(previous__isnull=True)
+    # previous__isnull breaks functionality if someone creates a new state
+    # without a previous state set.  since we know the initial state
+    # is id=1 per fixtures/state.json, use that instead.
+    return State.objects.get(id=1)


### PR DESCRIPTION
Background:

If a new state is created where `newstate.previous == Null` then the query for get_first_state returns two states, breaking Querysets that are looking for objects whose State is `Active`.  Since the fixture linked below clearly states that the initial `Active` state has id=1, let's use that to identify the initial state.

Refer to https://github.com/cfpb/idea-box/blob/master/src/idea/fixtures/state.json which is loaded in the migrations
