### PR TITLE
Fix pagination when browsing tags

### DIFF
--- a/idea/templates/idea/banner_detail.html
+++ b/idea/templates/idea/banner_detail.html
@@ -106,15 +106,15 @@
                 <div class="pagination">
                     <ul>
                         {% if ideas.has_previous %}
-                            <li><a href="?page_num={{ ideas.previous_page_number }}"><i class="icon-chevron-left"></i></a></li>
+                            <li><a href="?{% if page_tags %}tags={{ page_tags|join:',' }}&{% endif %}page_num={{ ideas.previous_page_number }}"><i class="icon-chevron-left"></i></a></li>
                         {% endif %}
                         {% for page in ideas.paginator.page_range %}
                             <li class="{% if page == ideas.number %}active{% endif %}">
-                                <a href="?page_num={{ page }}">{{ page }}</a>
+                                <a href="?{% if page_tags %}tags={{ page_tags|join:',' }}&{% endif %}page_num={{ page }}">{{ page }}</a>
                             </li>
                         {% endfor %}
                         {% if ideas.has_next %}
-                            <li><a href="?page_num={{ ideas.next_page_number }}"><i class="icon-chevron-right"></i></a></li>
+                            <li><a href="?{% if page_tags %}tags={{ page_tags|join:',' }}&{% endif %}page_num={{ ideas.next_page_number }}"><i class="icon-chevron-right"></i></a></li>
                         {% endif %}
                     </ul>
                 </div>

--- a/idea/templates/idea/list.html
+++ b/idea/templates/idea/list.html
@@ -82,15 +82,15 @@
                 <div class="pagination">
                     <ul>
                         {% if ideas.has_previous %}
-                            <li><a href="?page_num={{ ideas.previous_page_number }}"><i class="icon-chevron-left"></i></a></li>
+                        <li><a href="?{% if page_tags %}tags={{ page_tags|join:',' }}&{% endif %}page_num={{ ideas.previous_page_number }}"><i class="icon-chevron-left"></i></a></li>
                         {% endif %}
                         {% for page in ideas.paginator.page_range %}
                             <li class="{% if page == ideas.number %}active{% endif %}">
-                                <a href="?page_num={{ page }}">{{ page }}</a>
+                                <a href="?{% if page_tags %}tags={{ page_tags|join:',' }}&{% endif %}page_num={{ page }}">{{ page }}</a>
                             </li>
                         {% endfor %}
                         {% if ideas.has_next %}
-                            <li><a href="?page_num={{ ideas.next_page_number }}"><i class="icon-chevron-right"></i></a></li>
+                            <li><a href="?{% if page_tags %}tags={{ page_tags|join:',' }}&{% endif %}page_num={{ ideas.next_page_number }}"><i class="icon-chevron-right"></i></a></li>
                         {% endif %}
                     </ul>
                 </div>

--- a/idea/views.py
+++ b/idea/views.py
@@ -129,6 +129,7 @@ def list(request, sort_or_state=None):
     return _render(request, 'idea/list.html', {
         'sort_or_state': sort_or_state,
         'ideas': page,
+        'page_tags': tag_strs,
         'tags': tags,  # list of popular tags
         'banner': banner,
         'browse_banners': browse_banners,
@@ -141,7 +142,7 @@ def banner_list(request):
     past_banners = Banner.objects.exclude(is_private=True).filter(end_date__lt=date.today()).order_by('end_date')
     return _render(request, 'idea/banner_list.html', {
         'current_banners': current_banners,
-	'past_banners': past_banners,
+        'past_banners': past_banners,
     })
 
 def vote_up(idea, user):
@@ -469,6 +470,7 @@ def banner_detail(request, banner):
 
     return _render(request, 'idea/banner_detail.html', {
         'ideas': page,
+        'page_tags': tag_strs,
         'tags': tags,  # list of tags associated with banner ideas
         'banner': banner,
         'is_current_banner': is_current_banner,


### PR DESCRIPTION
Currently, if you're browsing a page with tags (e.g. `/idea/list/?tags=tagname`), if there are enough records for there to be pagination at the bottom, the pagination links remove the tags from the context (e.g. `/idea/list/?page_num=2`).

This update checks to see if the current context has any tags, and appends them to the pagination urls if appropriate.