### PR TITLE
Pin a bunch of requirements; use core.taggit by default

### DIFF
--- a/idea/settings/base.py
+++ b/idea/settings/base.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'mptt',
     'core.custom_comments',  # from Collab
-    'taggit',
+    'core.taggit',
 ]
 
 ROOT_URLCONF = 'idea.example_urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django==1.5
 django-cache-tools
-django-mptt
+django-mptt==0.7.4
 django-taggit
 -e git+https://github.com/cfpb/collab.git#egg=collab
 pillow
-south
+south==0.7.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ django-cache-tools
 django-mptt==0.7.4
 django-taggit
 -e git+https://github.com/cfpb/collab.git#egg=collab
-pillow
+pillow==3.0.0
 south==0.7.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ django-nose==1.4.2
 django-webtest==1.7.8
 exam
 mock
-webtest
+webtest==2.0.20

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-django-nose
-django-webtest
+django-nose==1.4.2
+django-webtest==1.7.8
 exam
 mock
 webtest


### PR DESCRIPTION
Newer versions are not compatible with this project.

See https://github.com/cfpb/idea-box/issues/97#issuecomment-308565741 and https://github.com/cfpb/idea-box/issues/95#issuecomment-175143283

@m3brown Any reason you know of that this would be a bad idea?